### PR TITLE
Change formula

### DIFF
--- a/code.js
+++ b/code.js
@@ -4376,7 +4376,8 @@ function activeHero(hero){
 			var rawDmg = (thisEffAtk * effectiveBonus | 0) + ((thisEffAtk * effectiveBonus | 0) * weaponAdvantageBonus | 0) + (dmgBoost | 0);
 			var reduceDmg = relevantDef + (relevantDef * enemyDefModifier | 0);
 			var dmg = (rawDmg - reduceDmg) * weaponModifier | 0;
-			dmg = (dmg * dmgMultiplier | 0) - (dmg * (1-dmgReduction) | 0);
+			dmg = dmg * dmgMultiplier | 0;
+			dmg -= dmg * (1-dmgReduction) | 0;
 
 			//Pushing Shield check
 			if (defensiveSpecialActivated && (enemy.has("Shield Pulse 2") || enemy.has("Shield Pulse 3"))){


### PR DESCRIPTION
Some special skills (e.g., Glimmer) are ignored damage reduction skills (e.g., Crusader's Ward).
https://github.com/Andu2/FEH-Mass-Simulator/blob/master/code.js#L4379

The following is how I looked into damage.

Challenger:
  Reinhardt (5★+10 +atk -def);Weapon: Dire Thunder;Special: Glimmer;A: Death Blow 3;B: Swordbreaker 3;C: Goad Cavalry;

Enemy:
  Sigurd(41/52/32/35/20) in Paralogue 13-1 Lunatic, who has same Res as Rarity 5. 

In MDS
  Reinhardt attacks Sigurd for 22-9-9-**31** damage

    Round 1: Reinhardt initiates;
    Reinhardt gets +6 Atk from initiating with Death Blow 3.;
    Reinhardt can make an automatic follow-up attack.;
    Reinhardt's attack is multiplied by 1.2 because of weapon advantage.;
    Sigurd's Divine Tyrfing reduces Reinhardt's magic damage by 50%.;
    Reinhardt attacks Sigurd for 22 damage.;
    Reinhardt 42 : Sigurd 19;
    Reinhardt attacks again with Dire Thunder.;
    Reinhardt's attack is multiplied by 1.2 because of weapon advantage.;
    Sigurd's Crusader's Ward reduces Reinhardt's consecutive damage by 80%.;
    Reinhardt attacks Sigurd for 9 damage.;
    Reinhardt 42 : Sigurd 10;
    Reinhardt's attack is multiplied by 1.2 because of weapon advantage.;
    Sigurd's Crusader's Ward reduces Reinhardt's consecutive damage by 80%.;
    Reinhardt attacks Sigurd for 9 damage.;
    Reinhardt 42 : Sigurd 1;
    Reinhardt attacks again with Dire Thunder.;
    Reinhardt activates Glimmer.;
    Reinhardt's attack is multiplied by 1.2 because of weapon advantage.;
    Sigurd's Crusader's Ward reduces Reinhardt's consecutive damage by 80%.;
    Reinhardt attacks Sigurd for 31 damage.;
    Reinhardt 42 : Sigurd 0;

In Game
  Reinhardt attacks Sigurd for 22-9-9-**14** damage.
  https://twitter.com/krbysh_x86/status/928617044005629953
  Sorry for Japanese client.