### PR TITLE
Outcome oriented stats

### DIFF
--- a/code.js
+++ b/code.js
@@ -238,7 +238,12 @@ function initOptions(){
 	statistics.enemies.melee = 0;
 	statistics.enemies.melee_outcome = [0,0,0];
 	statistics.enemies.ranged = 0;
-	statistics.enemies.ranged_outcome = [0,0,0];
+    statistics.enemies.ranged_outcome = [0,0,0];
+    
+    statistics.wins = { min: 0, average: 0, max: 0, count: 0};
+    statistics.losses = { min: 0, average: 0, max: 0, count: 0};
+    statistics.inconclusives_challenger = { min: 0, average: 0, max: 0, count: 0};
+    statistics.inconclusives_enemy = { min: 0, average: 0, max: 0, count: 0};
 
 	//Holder for challenger options and pre-calculated stats
 	challenger = {};
@@ -4094,10 +4099,46 @@ function resetStatistics(){
 	statistics.enemies.melee = 0;
 	statistics.enemies.melee_outcome = [0,0,0];
 	statistics.enemies.ranged = 0;
-	statistics.enemies.ranged_outcome = [0,0,0];
+    statistics.enemies.ranged_outcome = [0,0,0];
+    
+    // OUTCOME ORIENTED
+    let keys = ['wins', 'losses', 'inconclusives_challenger', 'inconclusives_enemy'];
+    keys.map(key => statistics[key]).forEach(stat => {
+        stat.min = Number.MAX_SAFE_INTEGER;
+        stat.max = -Number.MAX_SAFE_INTEGER;
+        stat.average = 0;
+        stat.count = 0;
+    });
+    // OUTCOME ORIENTED END
 }
 
 function collectStatistics(challenger, enemy, outcome){
+
+    // OUTCOME ORIENTED
+    let key_hp_pair = [];
+    switch (outcome) {
+        case 'win': 
+            key_hp_pair.push(['wins', challenger.hp]); 
+            break;
+        case 'loss': 
+            key_hp_pair.push(['losses', enemy.hp]); 
+            break;
+        default:
+            key_hp_pair.push(['inconclusives_challenger', challenger.hp]);
+            key_hp_pair.push(['inconclusives_enemy', enemy.hp]);
+            break;
+    }
+    key_hp_pair.forEach(pair => {
+        let key = pair[0];
+        let hp = pair[1];
+        let stat = statistics[key];
+        stat.min = Math.min(stat.min, hp);
+        stat.max = Math.max(stat.max, hp);
+        stat.average += hp;
+        stat.count++;
+    })
+    // OUTCOME ORIENTED END
+
 	//Challenger
 	if (statistics.challenger.res_hp_max == -1){
 		statistics.challenger.res_hp_max = challenger.hp;
@@ -4193,7 +4234,17 @@ function collectStatistics(challenger, enemy, outcome){
 function calculateStatistics(){
 	//console.log(statistics.enemies.list);
 	statistics.challenger.res_hp_avg = Math.round(statistics.challenger.res_hp_avg / statistics.enemies.list.length);
-	statistics.enemies.res_hp_avg = Math.round(statistics.enemies.res_hp_avg / statistics.enemies.list.length);
+    statistics.enemies.res_hp_avg = Math.round(statistics.enemies.res_hp_avg / statistics.enemies.list.length);
+    
+    // OUTCOME ORIENTED
+    let keys = ['wins', 'losses', 'inconclusives_challenger', 'inconclusives_enemy'];
+    keys.map(key => statistics[key]).forEach(stat => {
+        if (stat.min == Number.MAX_SAFE_INTEGER) stat.min = '-';
+        if (stat.max == -Number.MAX_SAFE_INTEGER) stat.max = '-';
+        if (stat.count == 0) stat.average = '-';
+        else stat.average = Math.round(stat.average / stat.count);
+    });
+    // OUTCOME ORIENTED END
 }
 
 function updateStatisticsUI(){
@@ -4207,7 +4258,29 @@ function updateStatisticsUI(){
 
 	$("#enemies_res_hp_max").html(statistics.enemies.res_hp_max);
 	$("#enemies_res_hp_min").html(statistics.enemies.res_hp_min);
-	$("#enemies_res_hp_avg").html(statistics.enemies.res_hp_avg);
+    $("#enemies_res_hp_avg").html(statistics.enemies.res_hp_avg);
+    
+    // OUTCOME ORIENTED
+    $("#wins_res_hp_max").html(statistics.wins.max);
+    $("#wins_res_hp_min").html(statistics.wins.min);
+    $("#wins_res_hp_avg").html(statistics.wins.average);
+
+    $("#losses_res_hp_max").html(statistics.losses.max);
+    $("#losses_res_hp_min").html(statistics.losses.min);
+    $("#losses_res_hp_avg").html(statistics.losses.average);
+
+    $("#inconclusives_challenger_res_hp_max").html(statistics.inconclusives_challenger.max);
+    $("#inconclusives_challenger_res_hp_min").html(statistics.inconclusives_challenger.min);
+    $("#inconclusives_challenger_res_hp_avg").html(statistics.inconclusives_challenger.average);
+
+    $("#inconclusives_enemy_res_hp_max").html(statistics.inconclusives_enemy.max);
+    $("#inconclusives_enemy_res_hp_min").html(statistics.inconclusives_enemy.min);
+    $("#inconclusives_enemy_res_hp_avg").html(statistics.inconclusives_enemy.average);
+
+    $("#wins_res_count").html(statistics.wins.count);
+    $("#losses_res_count").html(statistics.losses.count);
+    $("#inconclusive_res_count").html(statistics.inconclusives_enemy.count + statistics.inconclusives_challenger.count);
+    // OUTCOME ORIENTED END
 
 	//Draw Chart
 	drawChart();

--- a/index.html
+++ b/index.html
@@ -383,34 +383,70 @@
 			<div id="frame_statistics" style="display: none;">
 				<div id="rules_bar_top">
 					Statistics
-				</div>
-				<div id="adj_title">Challenger</div>
-				<div class="adj_status">
-					<div class="stat_desc">Resulting HP: Maximum</div>
-					<div class="stat_value" id="challenger_res_hp_max">-</div>
-				</div>
-				<div class="adj_status">
-					<div class="stat_desc">Resulting HP: Minimum</div>
-					<div class="stat_value" id="challenger_res_hp_min">-</div>
-				</div>
-				<div class="adj_status">
-					<div class="stat_desc">Resulting HP: Average</div>
-					<div class="stat_value" id="challenger_res_hp_avg">-</div>
-				</div>
-				<div style="line-height:40%;"><br></div>
-				<div id="adj_title">Enemies</div>
-				<div class="adj_status">
-					<div class="stat_desc">Resulting HP: Maximum</div>
-					<div class="stat_value" id="enemies_res_hp_max">-</div>
-				</div>
-				<div class="adj_status">
-					<div class="stat_desc">Resulting HP: Minimum</div>
-					<div class="stat_value" id="enemies_res_hp_min">-</div>
-				</div>
-				<div class="adj_status">
-					<div class="stat_desc">Resulting HP: Average</div>
-					<div class="stat_value" id="enemies_res_hp_avg">-</div>
-				</div>
+                </div>
+
+                <div id="adj_title"><span id="wins_res_count">-</span> Wins <span>(Challenger HP)</span></div>
+                <div class='adj_status_compact'>
+                    <label>
+                        <span>max</span>
+                        <span id="wins_res_hp_max">-</span>
+                    </label>
+                    <label>
+                        <span>avg</span>
+                        <span id="wins_res_hp_avg">-</span>
+                    </label>
+                    <label>
+                        <span>min</span>
+                        <span id="wins_res_hp_min">-</span>
+                    </label>
+                </div>
+
+                <div id="adj_title"><span id="losses_res_count">-</span> Losses <span>(Enemy HP)</span></div>
+                <div class='adj_status_compact'>
+                    <label>
+                        <span>max</span>
+                        <span id="losses_res_hp_max">-</span>
+                    </label>
+                    <label>
+                        <span>avg</span>
+                        <span id="losses_res_hp_avg">-</span>
+                    </label>
+                    <label>
+                        <span>min</span>
+                        <span id="losses_res_hp_min">-</span>
+                    </label>
+                </div>
+
+                <div id="adj_title"><span id="inconclusive_res_count">-</span> Inconclusives</div>
+                <div class='adj_status_compact'>
+                    <label>
+                        <span>max</span>
+                        <span id="inconclusives_challenger_res_hp_max">-</span>
+                    </label>
+                    <label>
+                        <span>avg</span>
+                        <span id="inconclusives_challenger_res_hp_avg">-</span>
+                    </label>
+                    <label>
+                        <span>min</span>
+                        <span id="inconclusives_challenger_res_hp_min">-</span>
+                    </label>
+                </div>
+                <div class='adj_status_compact'>
+                    <label>
+                        <span>max</span>
+                        <span id="inconclusives_enemy_res_hp_max">-</span>
+                    </label>
+                    <label>
+                        <span>avg</span>
+                        <span id="inconclusives_enemy_res_hp_avg">-</span>
+                    </label>
+                    <label>
+                        <span>min</span>
+                        <span id="inconclusives_enemy_res_hp_min">-</span>
+                    </label>
+                </div>
+
 				<div style="line-height:40%;"><br></div>
 				<div id="adj_title">Charts</div>
 				<div class="adj_status">

--- a/style.css
+++ b/style.css
@@ -793,6 +793,30 @@ svg > g > g:last-child { pointer-events: none }
 	border-radius:3px;
 }
 
+.adj_status_compact {
+    display: flex;
+    font-size: 12px;
+    line-height: 1.5em;
+}
+.adj_status_compact label {
+    display: block;
+    flex: 1;
+    padding: 0px 12px;
+}
+.adj_status_compact label span:nth-of-type(1) {
+    float: left;
+    opacity: 0.6;
+}
+.adj_status_compact label span:nth-of-type(2) {
+    float: right;
+}
+#adj_title span {
+    opacity: 0.5;
+    font-size: 12px;
+    line-height: 24px;
+    vertical-align: top;
+}
+
 /*Options///////////////////////////////////////*/
 #frame_settings{
 	border-radius:4px;


### PR DESCRIPTION
I realized that increasing the number of rows in the ui would make it unpleasantly larger (with a lot of empty space in the bottom).
In order to avoid increacing the ui height I changed the numbers layout.
I removed the old Challenger/Enemies and replaced them with Wins/Losses/Inconclusives

I apologize in advance for technical github related problems, this is the first time I contribute to someone elses project by myself.