### PR TITLE
Adding DPT to custom opponent lists

### DIFF
--- a/json/custom_lists.json
+++ b/json/custom_lists.json
@@ -1,11 +1,16 @@
 [
 	{
 		"name": "Sundere's List",
-		"key": "1vwymjyksChc84apCilDJtU2oit2xh--tcx9neeziF1M",		
+		"key": "1vwymjyksChc84apCilDJtU2oit2xh--tcx9neeziF1M",
 		"range": "&max-col=1"
 	},	{
 		"name": "700-710 Tally",
-		"key": "1sEagXyOHdFlANYNXIT5VKRMiRExXbjZYallR0x3aAks",		
+		"key": "1sEagXyOHdFlANYNXIT5VKRMiRExXbjZYallR0x3aAks",
+		"range": "&max-col=1"
+	},	{
+		"name": "DPT List",
+		"key": "124jN3Ovc0m86EnN84mrbHJu7Wce487BNKTwa6uelSHQ",
 		"range": "&max-col=1"
 	}
+
 ]


### PR DESCRIPTION
I'm Deltran - I have an OK FEH Youtube Channel, and on it I use a custom Arena list to evaluate builds.  I'd love it if it could be apart of the FEH Mass Simulator!